### PR TITLE
Remove `num-bigint` as a crate dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ ark-ec = { version = "0.4.2", default-features = false }
 hmac = { version = "0.12.1", default-features = false }
 sha2 = { version = "0.10.6", default-features = false }
 hkdf = { version = "0.12.3", default-features = false }
-num-bigint = { version = "0.4.3", default-features = false }
 ark-serialize = { version = "0.4.2", default-features = false }
 libm = "0.2.7"
 
@@ -27,6 +26,7 @@ rand_core = {version = "0.6.4", features = ["getrandom"] }
 hex = { version = "0.4.3" }
 hex-literal = { version = "0.4.1" }
 json = { version = "0.12.4" }
+num-bigint = { version = "0.4.3" }
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,8 @@ use ark_ec::hashing::map_to_curve_hasher::MapToCurveBasedHasher;
 use ark_ec::hashing::HashToCurve;
 use ark_ec::pairing::Pairing;
 use ark_ec::AffineRepr;
-use ark_ff::{field_hashers::DefaultFieldHasher, BigInteger256};
 use ark_ff::PrimeField;
+use ark_ff::{field_hashers::DefaultFieldHasher, BigInteger256};
 use ark_std::Zero;
 use hkdf::Hkdf;
 use sha2::{Digest, Sha256};
@@ -606,7 +606,9 @@ mod test {
     fn test_sign_against_noble_with_default_private_key() {
         let signature = sign(
             // Using the mini-app at the bottom of https://paulmillr.com/noble/
-            hex_string_to_big_int("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+            hex_string_to_big_int(
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            ),
             // "greetings from noble"
             &hex::decode("011a775441ecb14943130a16f00cdd41818a83dd04372f3259e3ca7237e3cdaa")
                 .unwrap(),
@@ -650,7 +652,9 @@ mod test {
     fn test_sign_against_noble_with_random_private_key() {
         let signature = sign(
             // Using the mini-app at the bottom of https://paulmillr.com/noble/
-            hex_string_to_big_int("22ae2c98fe58a9bfae1b5acef4258a4e65593a21de5487dc3357184235ebd5ff"),
+            hex_string_to_big_int(
+                "22ae2c98fe58a9bfae1b5acef4258a4e65593a21de5487dc3357184235ebd5ff",
+            ),
             // Verify the hash with `echo -n 'Arnaud testing. 1. 2. Over. Kshhh.' | openssl dgst -sha256`
             &hex::decode("254958ab7082ba726466464e4118d86d5b19f24629b5ecfe539253fa2c821a79")
                 .unwrap(),
@@ -668,7 +672,9 @@ mod test {
 
     #[test]
     fn test_verify() {
-        let pk = sk_to_pk(hex_string_to_big_int("22ae2c98fe58a9bfae1b5acef4258a4e65593a21de5487dc3357184235ebd5ff"));
+        let pk = sk_to_pk(hex_string_to_big_int(
+            "22ae2c98fe58a9bfae1b5acef4258a4e65593a21de5487dc3357184235ebd5ff",
+        ));
         // Verify the hash with `echo -n 'Arnaud testing. 1. 2. Over. Kshhh.' | openssl dgst -sha256`
         let message =
             hex::decode("254958ab7082ba726466464e4118d86d5b19f24629b5ecfe539253fa2c821a79")
@@ -685,9 +691,15 @@ mod test {
         let dst = &"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_"
             .as_bytes()
             .to_vec();
-        let sk1 = hex_string_to_big_int("22ae2c98fe58a9bfae1b5acef4258a4e65593a21de5487dc3357184235ebd5ff");
-        let sk2 = hex_string_to_big_int("4b8e9a78f3da90c1f03160d9a904eba83f70abe4c0364ec4c1a37b9dd32cfe0d");
-        let sk3 = hex_string_to_big_int("0179b2fa76e0b267c9eae3ecec1f9beb31f1c2e25a71b70cc465d20afd835876");
+        let sk1 = hex_string_to_big_int(
+            "22ae2c98fe58a9bfae1b5acef4258a4e65593a21de5487dc3357184235ebd5ff",
+        );
+        let sk2 = hex_string_to_big_int(
+            "4b8e9a78f3da90c1f03160d9a904eba83f70abe4c0364ec4c1a37b9dd32cfe0d",
+        );
+        let sk3 = hex_string_to_big_int(
+            "0179b2fa76e0b267c9eae3ecec1f9beb31f1c2e25a71b70cc465d20afd835876",
+        );
 
         // Verify the digests with `echo -n 'Arnaud is testing {one,two,three}' | openssl dgst -sha256`
         let msg1 = hex::decode("0c1c81866dafbd0e9e3dc275ae3e47a82d1ce3b97696553eb3f86c4246dda0e4")

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,8 +6,8 @@ use ark_bls12_381::Fq2;
 use ark_bls12_381::{Bls12_381, Fq, Fr};
 use ark_ec::pairing::PairingOutput;
 use ark_ec::short_weierstrass::{Affine, Projective};
+use ark_ff::BigInteger256;
 use hmac::Hmac;
-use num_bigint::BigInt;
 use sha2::Sha256;
 
 /// Type alias for BLS' base field
@@ -32,8 +32,9 @@ pub type BLS12381Pairing = PairingOutput<Bls12_381>;
 /// The spec often talks about "octets strings". We alias `Vec<u8>` to have the code read closer to the spec.
 pub type Octets = Vec<u8>;
 
-/// A secret key is just a `BigInt`
-pub type SecretKey = BigInt;
+/// A secret key is an integer between 0 and the base field modulus
+/// In other words: a field element.
+pub type SecretKey = BigInteger256;
 
 /// Represents a point in G1
 /// (we're using the "minimal-pubkey-size" variant of the BLS spec)

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,6 @@ use ark_bls12_381::Fq2;
 use ark_bls12_381::{Bls12_381, Fq, Fr};
 use ark_ec::pairing::PairingOutput;
 use ark_ec::short_weierstrass::{Affine, Projective};
-use ark_ff::BigInteger256;
 use hmac::Hmac;
 use sha2::Sha256;
 
@@ -34,7 +33,8 @@ pub type Octets = Vec<u8>;
 
 /// A secret key is an integer between 0 and the base field modulus
 /// In other words: a field element.
-pub type SecretKey = BigInteger256;
+/// To obtain a [`SecretKey`] from bytes, use `SecretKey::from_be_bytes_mod_order(&bytes)`.
+pub type SecretKey = BLSFr;
 
 /// Represents a point in G1
 /// (we're using the "minimal-pubkey-size" variant of the BLS spec)

--- a/tests/cases.rs
+++ b/tests/cases.rs
@@ -1,4 +1,4 @@
-use ark_ff::BigInteger;
+use ark_ff::PrimeField;
 use bls_on_arkworks::types::{Octets, SecretKey};
 use std::fs;
 
@@ -275,17 +275,5 @@ fn prefixed_hex_string_to_secret_key(s: &str) -> SecretKey {
     non_prefixed.remove(0);
 
     let bytes = hex::decode(non_prefixed).unwrap();
-    let mut bits = vec![false; 8*bytes.len()];
-    for (i, byte) in bytes.iter().enumerate() {
-        bits[8*i] = byte & 0b10000000 > 0;
-        bits[8*i+1] = byte & 0b01000000 > 0;
-        bits[8*i+2] = byte & 0b00100000 > 0;
-        bits[8*i+3] = byte & 0b00010000 > 0;
-        bits[8*i+4] = byte & 0b00001000 > 0;
-        bits[8*i+5] = byte & 0b00000100 > 0;
-        bits[8*i+6] = byte & 0b00000010 > 0;
-        bits[8*i+7] = byte & 0b00000001 > 0;
-    }
-
-    SecretKey::from_bits_be(&bits)
+    SecretKey::from_be_bytes_mod_order(&bytes)
 }

--- a/tests/cases.rs
+++ b/tests/cases.rs
@@ -1,7 +1,6 @@
+use ark_ff::BigInteger;
 use bls_on_arkworks::types::{Octets, SecretKey};
 use std::fs;
-
-use num_bigint::BigInt;
 
 pub fn aggregate() -> Vec<AggregateCase> {
     let paths = fs::read_dir("tests/aggregate").unwrap();
@@ -190,7 +189,7 @@ pub fn sign_cases() -> Vec<SignCase> {
             let content = fs::read_to_string(path.clone()).unwrap();
             let parsed_content = json::parse(&content).unwrap();
             let private_key =
-                prefixed_hex_string_to_bigint(&parsed_content["input"]["privkey"].to_string());
+                prefixed_hex_string_to_secret_key(&parsed_content["input"]["privkey"].to_string());
             let message =
                 prefixed_hex_string_to_bytes(&parsed_content["input"]["message"].to_string());
             let expected_signature = if parsed_content["output"].is_null() {
@@ -269,6 +268,24 @@ fn prefixed_hex_string_to_bytes(s: &str) -> Vec<u8> {
 }
 
 // 0x1234 -> 4660
-fn prefixed_hex_string_to_bigint(s: &str) -> BigInt {
-    BigInt::parse_bytes(s.clone().replace("0x", "").as_bytes(), 16).unwrap()
+fn prefixed_hex_string_to_secret_key(s: &str) -> SecretKey {
+    // Remove the "0x" prefix
+    let mut non_prefixed = s.to_string();
+    non_prefixed.remove(0);
+    non_prefixed.remove(0);
+
+    let bytes = hex::decode(non_prefixed).unwrap();
+    let mut bits = vec![false; 8*bytes.len()];
+    for (i, byte) in bytes.iter().enumerate() {
+        bits[8*i] = byte & 0b10000000 > 0;
+        bits[8*i+1] = byte & 0b01000000 > 0;
+        bits[8*i+2] = byte & 0b00100000 > 0;
+        bits[8*i+3] = byte & 0b00010000 > 0;
+        bits[8*i+4] = byte & 0b00001000 > 0;
+        bits[8*i+5] = byte & 0b00000100 > 0;
+        bits[8*i+6] = byte & 0b00000010 > 0;
+        bits[8*i+7] = byte & 0b00000001 > 0;
+    }
+
+    SecretKey::from_bits_be(&bits)
 }


### PR DESCRIPTION
This PR removes `num-bigint` as a direct create dependency. I'm still keeping it in dev deps because I need it to parse decimal strings. Other than that we're using Arkwork's `Bigint` entirely!

This PR also up-levels `SecretKey`: it's no longer an arbitrary `BigInt`, it's now a proper field element (`Fr`). This means we automatically enforce that it's between 0 and p-1.

It took a bit of work to find `from_be_bytes_mod_order`; glad it exists.