### PR TITLE
Release 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "bls_on_arkworks"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "bls_on_arkworks"
 description = "A rust crate implementing the latest IETF draft for BLS signatures on top of the Arkworks ecosystem"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/ArnaudBrousseau/bls_on_arkworks"
 readme = "README.md"
 homepage = "https://github.com/ArnaudBrousseau/bls_on_arkworks"
 keywords = ["cryptography", "BLS", "BLS12381", "ethereum", "signature"]
-categories = ["cryptography"]
+categories = ["cryptography", "no_std"]
 
 [dependencies]
 ark-ff = { version = "0.4.2", default-features = false }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use ark_serialize::SerializationError;
 
 /// Error enum to wrap underlying failures in BLS operations, or wrap errors from dependencies.
-/// Inspired by the excellent https://blog.burntsushi.net/rust-error-handling
+/// Inspired by this excellent post: <https://blog.burntsushi.net/rust-error-handling>
 #[derive(Debug)]
 pub enum BLSError {
     /// Happens when the infinity bit is set in an encoding point, but the rest of the bytes aren't correctly zero'd


### PR DESCRIPTION
Branch to release a new version of this crate! Since 0.1.0 we've had:
- #2 which adds no-std support
- #5 which drastically simplifies serialization
- #6 which removes `num-bigint` from the direct dependencies list