### PR TITLE
Cargo.toml: `no_std` -> `no-std`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "bls_on_arkworks"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bls_on_arkworks"
 description = "A rust crate implementing the latest IETF draft for BLS signatures on top of the Arkworks ecosystem"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/ArnaudBrousseau/bls_on_arkworks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/ArnaudBrousseau/bls_on_arkworks"
 readme = "README.md"
 homepage = "https://github.com/ArnaudBrousseau/bls_on_arkworks"
 keywords = ["cryptography", "BLS", "BLS12381", "ethereum", "signature"]
-categories = ["cryptography", "no_std"]
+categories = ["cryptography", "no-std"]
 
 [dependencies]
 ark-ff = { version = "0.4.2", default-features = false }


### PR DESCRIPTION
Followup: messed up category in #7. I don't think it's worth yanking the release so let's roll forward! No code or test difference at all. This is simply to fix the crate categories 🙈 