### PR TITLE
Test no-std support in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: main
 
 jobs:
-  lints_n_tests:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,9 @@ jobs:
       - name: Run Tests
         run: |
           cargo check
-          cargo test --all          
+          cargo test --all
+
+      - name: Build with --no-default-features
+        run: |
+          cargo check --no-default-features
+          cargo build --no-default-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Rust CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: main
 
 jobs:
   lints_n_tests:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,5 @@ std = [
     "hmac/std",
     "sha2/std",
     "hkdf/std",
-    "num-bigint/std",
     "ark-serialize/std",
 ]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,7 @@
 //! Error enum to wrap underlying failures
+#[cfg(feature = "std")]
 use std::error::Error;
+#[cfg(feature = "std")]
 use std::fmt;
 
 use ark_serialize::SerializationError;
@@ -21,8 +23,10 @@ pub enum BLSError {
     WrongSizeForPublicKey(usize),
 }
 
+#[cfg(feature = "std")]
 impl Error for BLSError {}
 
+#[cfg(feature = "std")]
 impl fmt::Display for BLSError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
 use alloc::vec;
+use alloc::vec::Vec;
 use core::ops::{Add, AddAssign};
 
 use ark_bls12_381::g2::Config as G2Config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
+use alloc::vec;
 use core::ops::{Add, AddAssign};
 
 use ark_bls12_381::g2::Config as G2Config;


### PR DESCRIPTION
See #9 for context. I'm glad I did this: there were already some std-reliant code in the crate! Namely: implementing  std::error::Error, and one small use of `vec!` which didn't have the right `alloc` import. Onwards!